### PR TITLE
Messages as byte arrays

### DIFF
--- a/Sources/CombineMIDI/Array+chunked.swift
+++ b/Sources/CombineMIDI/Array+chunked.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-extension Array {
-    func chunked(into size: Int) -> [[Element]] {
-        return stride(from: 0, to: count, by: size).map {
-            Array(self[$0..<Swift.min($0 + size, count)])
-        }
-    }
-}

--- a/Sources/CombineMIDI/MIDIMessage.swift
+++ b/Sources/CombineMIDI/MIDIMessage.swift
@@ -42,7 +42,8 @@ public struct MIDIMessage {
         
         // System Real-Time Messages
         
-        /// Timing Clock. Send during synchronization
+        /// Timing Clock. Sent 24 times per quarter note when synchronization
+        /// is required.
         case timingClock = 0xF8
         
         /// Start. Message to start the current sequence.
@@ -65,67 +66,20 @@ public struct MIDIMessage {
         /// Number of bytes expected in a message with this status
         var bytesPerMessage: UInt8 {
             switch self {
-            case .noteOff:
+            case .noteOff, .noteOn, .aftertouch, .controlChange, .pitchBendChange:
                 return 3
-            case .noteOn:
-                return 3
-            case .aftertouch:
-                return 3
-            case .controlChange:
-                return 3
-            case .programChange:
+            case .programChange, .channelPressure:
                 return 2
-            case .channelPressure:
-                return 2
-            case .pitchBendChange:
-                return 3
-            case .tuneRequest:
-                return 1
-            case .timingClock:
-                return 1
-            case .start:
-                return 1
-            case .continue:
-                return 1
-            case .stop:
-                return 1
-            case .activeSensing:
-                return 1
-            case .systemReset:
+            case .tuneRequest, .timingClock, .start, .continue, .stop, .activeSensing, .systemReset:
                 return 1
             }
         }
         
         var hasChannel: Bool {
             switch self {
-                
-            case .noteOff:
+            case .noteOff, .noteOn, .aftertouch, .controlChange, .programChange, .channelPressure, .pitchBendChange:
                 return true
-            case .noteOn:
-                return true
-            case .aftertouch:
-                return true
-            case .controlChange:
-                return true
-            case .programChange:
-                return true
-            case .channelPressure:
-                return true
-            case .pitchBendChange:
-                return true
-            case .tuneRequest:
-                return false
-            case .timingClock:
-                return false
-            case .start:
-                return false
-            case .continue:
-                return false
-            case .stop:
-                return false
-            case .activeSensing:
-                return false
-            case .systemReset:
+            case .tuneRequest, .timingClock, .start, .continue, .stop, .activeSensing, .systemReset:
                 return false
             }
         }

--- a/Sources/CombineMIDI/MIDIMessage.swift
+++ b/Sources/CombineMIDI/MIDIMessage.swift
@@ -147,30 +147,8 @@ public struct MIDIMessage {
     /// - Parameters:
     ///   - bytes: Array of bytes . Different message types may be 1, 2, or 3 bytes
     ///   as determined by the first 4 bits (status). If the number of bytes does not match the expected number as
-
-extension MIDIMessage {
-    struct PartialMessage {
-        var data: [UInt8]
-        var status: Status? {
-            return Status(rawValue: data[0] & 0xF0)
-        }
-        var message: MIDIMessage? {
-            return MIDIMessage(bytes: data)
-        }
-        mutating func appending(byte: UInt8) -> MIDIMessage? {
-            data.append(byte)
-            return message
-        }
-    }
-    enum InstreamMessage {
-        case message(MIDIMessage)
-        case partial(PartialMessage)
-    }
-    static func from(byte: UInt8) -> InstreamMessage {
-        let partial = PartialMessage(data: [byte])
-        if let message = partial.message {
-            return .message(message)
-        }
-        return .partial(partial)
+    ///   denoted by the status the message will be uncomplete.
+    public init(bytes: [UInt8] = []) {
+        self.bytes = bytes
     }
 }

--- a/Sources/CombineMIDI/MIDIStream.swift
+++ b/Sources/CombineMIDI/MIDIStream.swift
@@ -6,12 +6,20 @@ struct MIDIStream {
     private var port = MIDIPortRef()
     
     init(client: MIDIClient, receive: @escaping (MIDIMessage) -> Void) {
+        // Currently read partial message
+        var currentMessage = MIDIMessage()
+        
         MIDIInputPortCreateWithBlock(client.client, client.generatePortName() as CFString, &port) { pointer, _ in
             pointer
                 .unsafeSequence()
                 .flatMap { $0.sequence() }
-                .chunked(into: 3)
-                .compactMap(MIDIMessage.init)
+                .reduce(into: [MIDIMessage]()) { messages, byte in
+                    currentMessage.bytes.append(byte)
+                    if currentMessage.isComplete {
+                        messages.append(currentMessage)
+                        currentMessage = MIDIMessage()
+                    }
+                }
                 .forEach(receive)
         }
         for i in 0...MIDIGetNumberOfSources() {


### PR DESCRIPTION
To allow partial and full messages in a single struct.

Messages can be created with no bytes, we could change that, but it would require more code.